### PR TITLE
Removing a *nix shell dependency in favor of a distutils function call

### DIFF
--- a/cmake_setup/cmake/__init__.py
+++ b/cmake_setup/cmake/__init__.py
@@ -4,8 +4,9 @@ import shutil
 import sys
 from setuptools import Extension
 from setuptools.command.build_ext import build_ext
+from distutils.spawn import find_executable
 
-CMAKE_EXE = os.environ.get('CMAKE_EXE', os.popen("which cmake").read().strip("\n"))
+CMAKE_EXE = os.environ.get('CMAKE_EXE', find_executable('cmake'))
 
 
 def check_for_cmake():


### PR DESCRIPTION
Not sure why my cmake install wasn't cooperating with me, so I haven't tested the change, but this should make cmake_setup work on systems that don't have "which" installed (aka Windows)